### PR TITLE
Add code-of-conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Numba Project Governance
 
-**NOTE: This document is in draft form and currently being revised.  It does not take effect until this notice is removed.**
-
 The purpose of this repository is to document the governance process of Numba.
 This document clarifies how decisions are made and how the various elements of
 our community interact, including the relationship between open source
@@ -9,10 +7,14 @@ collaborative development and work that may be funded by for-profit or
 non-profit entities.
 
 ## Table of Contents
-   
+
+**NOTE: This is work-in-progress and will be updated as new documents are being accepted.**
+
+<!-- Draft for these documents are in the `draft` branch
 * [Main Governance Document](governance.md)
 * [Current People](people.md)
 * [Communication Channels](communication.md)
+-->
 * [Code of Conduct](code-of-conduct.md)
 
 ## Acknowledgements

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -8,8 +8,8 @@ documentation, submitting pull requests or patches, and other activities.
 We are committed to making participation in this project a harassment-free
 experience for everyone, regardless of level of experience, gender, gender
 identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, religion, nationality, socio-economic status, educational level, 
-family status, culture, or political belief.
+body size, race, ethnicity, age, religion, nationality, socio-economic status,
+educational level, family status, culture, or political belief.
 
 Examples of unacceptable behavior by participants include:
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,61 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+A working group of community members is committed to promptly addressing any
+reported issues. The working group is made up of Numba contributors and users.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the working group by e-mail (numba-conduct@googlegroups.com).
+Messages sent to this e-mail address will not be publicly visible but only to
+the working group members. The working group currently includes
+
+- Siu Kwan Lam
+- Stan Seibert
+- Stuart Archibald
+
+All complaints will be reviewed and investigated and will result in a response
+that is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version],
+and the [Swift Code of Conduct][swift].
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/
+[swift]: https://swift.org/community/#code-of-conduct
+

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -8,7 +8,8 @@ documentation, submitting pull requests or patches, and other activities.
 We are committed to making participation in this project a harassment-free
 experience for everyone, regardless of level of experience, gender, gender
 identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, religion, or nationality.
+body size, race, ethnicity, age, religion, nationality, socio-economic status, educational level, 
+family status, culture, or political belief.
 
 Examples of unacceptable behavior by participants include:
 
@@ -58,4 +59,3 @@ and the [Swift Code of Conduct][swift].
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/3/0/
 [swift]: https://swift.org/community/#code-of-conduct
-


### PR DESCRIPTION
The COC document is adapted from https://github.com/pandas-dev/pandas-governance/blob/master/code-of-conduct.md.

We need approval from core members: @stuartarchibald, @seibert, @ehsantn, @DrTodd13, @sklam.